### PR TITLE
fixed osc.js to work with current node.js

### DIFF
--- a/lib/osc.js
+++ b/lib/osc.js
@@ -1,8 +1,7 @@
-require.paths.unshift(__dirname + '/node-jspack');
+// require.paths.unshift(__dirname + '/node-jspack');
 var buffer = require('buffer');
 var dgram = require('dgram');
-var sys = require('sys');
-
+var sys = require('util');
 var jspack = require('jspack').jspack;
 
 
@@ -151,7 +150,8 @@ var OSCTimeTag = function (time) {
 var Client = function (port, host) {
   this.port = port;
   this.host = host // || '127.0.0.1';
-  this._sock = dgram.createSocket(true);
+  this._sock = dgram.createSocket('udp4');
+  return this._sock;
 }
 Client.prototype = {
   send: function (msg) {


### PR DESCRIPTION
Hey,

I update your osc.js file to work the current version (v0.6.12) of node.js. Thought you might want pull it in.
